### PR TITLE
Update to the latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(incomplete_features)]
-#![feature(min_type_alias_impl_trait)]
 #![feature(type_alias_impl_trait)]
 #![feature(generic_associated_types)]
 #![feature(generators)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -66,7 +66,9 @@ pub enum Error {
 }
 
 pub trait Presto {
-    type ValueType<'a>: Serialize where Self: 'a;
+    type ValueType<'a>: Serialize
+    where
+        Self: 'a;
     type Seed<'a, 'de>: DeserializeSeed<'de, Value = Self>;
 
     fn value(&self) -> Self::ValueType<'_>;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -66,7 +66,7 @@ pub enum Error {
 }
 
 pub trait Presto {
-    type ValueType<'a>: Serialize;
+    type ValueType<'a>: Serialize where Self: 'a;
     type Seed<'a, 'de>: DeserializeSeed<'de, Value = Self>;
 
     fn value(&self) -> Self::ValueType<'_>;

--- a/src/types/option.rs
+++ b/src/types/option.rs
@@ -6,7 +6,10 @@ use serde::de::{self, DeserializeSeed, Deserializer, Visitor};
 use super::{Context, Presto, PrestoTy};
 
 impl<T: Presto> Presto for Option<T> {
-    type ValueType<'a> where T: 'a, = Option<T::ValueType<'a>>;
+    type ValueType<'a>
+    where
+        T: 'a,
+    = Option<T::ValueType<'a>>;
     type Seed<'a, 'de> = OptionSeed<'a, T>;
 
     fn value(&self) -> Self::ValueType<'_> {

--- a/src/types/option.rs
+++ b/src/types/option.rs
@@ -6,7 +6,7 @@ use serde::de::{self, DeserializeSeed, Deserializer, Visitor};
 use super::{Context, Presto, PrestoTy};
 
 impl<T: Presto> Presto for Option<T> {
-    type ValueType<'a> = Option<T::ValueType<'a>>;
+    type ValueType<'a> where T: 'a, = Option<T::ValueType<'a>>;
     type Seed<'a, 'de> = OptionSeed<'a, T>;
 
     fn value(&self) -> Self::ValueType<'_> {

--- a/src/types/seq.rs
+++ b/src/types/seq.rs
@@ -16,7 +16,7 @@ macro_rules! gen_seq {
     };
     ($ty:ident < $($bound:ident ),* >,  $insert:ident, $seed:ident) => {
         impl<T: Presto + $($bound+)*> Presto for $ty<T> {
-            type ValueType<'a> = impl Serialize;
+            type ValueType<'a> where T: 'a = impl Serialize;
             type Seed<'a, 'de> = $seed<'a, T>;
 
             fn value(&self) -> Self::ValueType<'_> {


### PR DESCRIPTION
Hello, thanks for this useful crate !

I tried to use this crate with the latest nightly, but it did not compile. 
The reason was that the `min_type_alias_impl_trait` feature had been removed.
So I changed it to compile. 

I don't understand`min_type_alias_impl_trait`, so there may be better code, but I will pull request!