### PR TITLE
Provide a feature flag for running as presto client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ readme = "README.md"
 [workspace]
 members = [".", "prusto-macros"]
 
+[features]
+default = []
+presto = []
+
 [dependencies]
 # self dependencies
 prusto-macros = { version = "0.2", path = "prusto-macros"}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prusto
 
-A [trino (f.k.a. prestosql)](https://trino.io/) client library written in rust.
+A [presto/trino](https://trino.io/) client library written in rust.
 
 
 ## Prerequisites
@@ -13,6 +13,13 @@ A [trino (f.k.a. prestosql)](https://trino.io/) client library written in rust.
 # Cargo.toml
 [dependencies]
 prusto = "0.4"
+```
+
+In order to use this crate as presto client, enable "presto" feature.
+```toml
+# Cargo.toml
+[dependencies]
+prusto = { version = "0.4", features = ["presto"] }
 ```
 
 ## Example

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,10 @@ use tokio::time::{sleep, Duration};
 
 use crate::auth::Auth;
 use crate::error::{Error, Result};
+#[cfg(not(feature = "presto"))]
 use crate::header::*;
+#[cfg(feature = "presto")]
+use crate::presto_header::*;
 use crate::selected_role::SelectedRole;
 use crate::session::{Session, SessionBuilder};
 use crate::transaction::TransactionId;

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,4 @@
-// request headers
+// request headers for trino
 pub static HEADER_USER: &str = "X-Trino-User";
 pub static HEADER_SOURCE: &str = "X-Trino-Source";
 pub static HEADER_CATALOG: &str = "X-Trino-Catalog";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@
 pub mod auth;
 pub mod client;
 pub mod error;
+#[cfg(not(feature = "presto"))]
 mod header;
+#[cfg(feature = "presto")]
+mod presto_header;
 pub mod models;
 pub mod selected_role;
 pub mod session;

--- a/src/presto_header.rs
+++ b/src/presto_header.rs
@@ -1,0 +1,31 @@
+// request headers for presto
+pub static HEADER_USER: &str = "X-Presto-User";
+pub static HEADER_SOURCE: &str = "X-Presto-Source";
+pub static HEADER_CATALOG: &str = "X-Presto-Catalog";
+pub static HEADER_SCHEMA: &str = "X-Presto-Schema";
+pub static HEADER_PATH: &str = "X-Presto-Path";
+pub static HEADER_TIME_ZONE: &str = "X-Presto-Time-Zone";
+#[allow(dead_code)]
+pub static HEADER_LANGUAGE: &str = "X-Presto-Language";
+pub static HEADER_TRACE_TOKEN: &str = "X-Presto-Trace-Token";
+pub static HEADER_SESSION: &str = "X-Presto-Session";
+pub static HEADER_ROLE: &str = "X-Presto-Role";
+pub static HEADER_PREPARED_STATEMENT: &str = "X-Presto-Prepared-Statement";
+pub static HEADER_TRANSACTION: &str = "X-Presto-Transaction-Id";
+pub static HEADER_CLIENT_INFO: &str = "X-Presto-Client-Info";
+pub static HEADER_CLIENT_TAGS: &str = "X-Presto-Client-Tags";
+pub static HEADER_CLIENT_CAPABILITIES: &str = "X-Presto-Client-Capabilities";
+pub static HEADER_RESOURCE_ESTIMATE: &str = "X-Presto-Resource-Estimate";
+pub static HEADER_EXTRA_CREDENTIAL: &str = "X-Presto-Extra-Credential";
+
+// response headers
+pub static HEADER_SET_CATALOG: &str = "X-Presto-Set-Catalog";
+pub static HEADER_SET_SCHEMA: &str = "X-Presto-Set-Schema";
+pub static HEADER_SET_PATH: &str = "X-Presto-Set-Path";
+pub static HEADER_SET_SESSION: &str = "X-Presto-Set-Session";
+pub static HEADER_CLEAR_SESSION: &str = "X-Presto-Clear-Session";
+pub static HEADER_SET_ROLE: &str = "X-Presto-Set-Role";
+pub static HEADER_ADDED_PREPARE: &str = "X-Presto-Added-Prepare";
+pub static HEADER_DEALLOCATED_PREPARE: &str = "X-Presto-Deallocated-Prepare";
+pub static HEADER_STARTED_TRANSACTION_ID: &str = "X-Presto-Started-Transaction-Id";
+pub static HEADER_CLEAR_TRANSACTION_ID: &str = "X-Presto-Clear-Transaction-Id";


### PR DESCRIPTION
## Description
Hi! Thank you for providing such a nice crate!
We've used this crate as Presto client by changing header keys into presto ones.

We're thinking it would be great if this upstream prusto crate would provide an option for running as presto client :)

## Changes
- adding file for declaring presto header
- importing trino/presto header file, depending on feature flag
- adding feature flag to run prusto as presto client

## Checklist
- compilation with no feature flag (cargo +nightly build)
- compilation with "presto" feature flag enabled (cargo +nightly build --features presto)

I'd like to hear your opinion about this change 🙏