### PR TITLE
Turn various conversion functions into proper traits and use `strum` to simplify string enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ prusto-macros = { version = "0.2", path = "prusto-macros"}
 # third party dependencies
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-derive_more = "0.99"
+strum = {version = "0.24", features = ["derive"]}
 bigdecimal = "0.3"
 thiserror = "1.0"
 chrono = "0.4"

--- a/src/models/ty.rs
+++ b/src/models/ty.rs
@@ -2,108 +2,117 @@ use std::fmt;
 
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use strum::{Display, EnumString, IntoStaticStr};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Raw Types representing what the Presto/Trino client application can return
+/// 
+/// Trino sourced from <https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/type/StandardTypes.java>
+/// Presto sourced from <https://github.com/prestodb/presto/blob/master/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java>
+#[derive(Clone, Copy, Debug, Eq, PartialEq, EnumString, IntoStaticStr, Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum RawPrestoTy {
+    /// A 64-bit signed two’s complement integer with a minimum value of `-2^63` and a maximum value of `2^63 - 1`.
     BigInt,
+    /// A 32-bit signed two’s complement integer with a minimum value of `-2^31` and a maximum value of `2^31 - 1`.
     Integer,
+    /// A 16-bit signed two’s complement integer with a minimum value of `-2^15` and a maximum value of `2^15 - 1`.
     SmallInt,
+    /// A 8-bit signed two’s complement integer with a minimum value of `-2^7` and a maximum value of `2^7 - 1`.
     TinyInt,
+    /// This type captures boolean values `true` and `false`.
     Boolean,
+    /// Calendar date (year, month, day).
     Date,
+    /// A fixed precision decimal number. Precision up to 38 digits is supported but performance is best up to 18 digits.
     Decimal,
+    /// A real is a 32-bit inexact, variable-precision implementing the IEEE Standard 754 for Binary Floating-Point Arithmetic.
     Real,
+    /// A double is a 64-bit inexact, variable-precision implementing the IEEE Standard 754 for Binary Floating-Point Arithmetic.
     Double,
+    /// A HyperLogLog sketch allows efficient computation of approx_distinct(). It starts as a sparse representation, switching to a dense representation when it becomes more efficient.
+    #[strum(serialize = "HyperLogLog")]
     HyperLogLog,
+    /// A quantile digest (qdigest) is a summary structure which captures the approximate distribution of data for a given input set, and can be queried to retrieve approximate quantile values from the distribution. The level of accuracy for a qdigest is tunable, allowing for more precise results at the expense of space.
+    ///
+    /// A qdigest can be used to give approximate answer to queries asking for what value belongs at a certain quantile. A useful property of qdigests is that they are additive, meaning they can be merged together without losing precision.
+    ///
+    /// A qdigest may be helpful whenever the partial results of approx_percentile can be reused. For example, one may be interested in a daily reading of the 99th percentile values that are read over the course of a week. Instead of calculating the past week of data with approx_percentile, qdigests could be stored daily, and quickly merged to retrieve the 99th percentile value.
     QDigest,
+    /// A T-digest (tdigest) is a summary structure which, similarly to qdigest, captures the approximate distribution of data for a given input set. It can be queried to retrieve approximate quantile values from the distribution.
+    /// 
+    /// TDigest has the following advantages compared to QDigest:
+    /// * higher performance
+    /// * lower memory usage
+    /// * higher accuracy at high and low percentiles
+    /// 
+    /// T-digests are additive, meaning they can be merged together.
+    TDigest,
+    /// A P4HyperLogLog sketch is similar to HyperLogLog, but it starts (and remains) in the dense representation.
+    #[strum(serialize = "P4HyperLogLog")]
     P4HyperLogLog,
+    /// Span of days, hours, minutes, seconds and milliseconds.
+    #[strum(serialize = "interval day to second")]
     IntervalDayToSecond,
+    /// Span of years and months.
+    #[strum(serialize = "interval year to month")]
     IntervalYearToMonth,
+    /// Calendar date and time of day without a time zone 
     Timestamp,
+    #[strum(serialize = "timestamp with time zone")]
+    /// Calendar date and time of day with a time zone 
     TimestampWithTimeZone,
+    /// Time of day (hour, minute, second) without a time zone.
     Time,
+    /// Time of day (hour, minute, second, millisecond) with a time zone.
+    #[strum(serialize = "time with time zone")]
     TimeWithTimeZone,
+    /// Variable length binary data.
     VarBinary,
+    /// Variable length character data with an optional maximum length.
     VarChar,
+    /// Fixed length character data. A CHAR type without length specified has a default length of 1. 
     Char,
+    /// A structure made up of fields that allows mixed types. The fields may be of any SQL type.
+    /// 
+    /// By default, row fields are not named, but names can be assigned.
     Row,
+    /// An array of the given component type.
     Array,
+    /// A map between the given component types.
     Map,
+    /// JSON value type, which can be a JSON object, a JSON array, a JSON number, a JSON string, `true`, `false` or null.
     Json,
+    /// An IP address that can represent either an IPv4 or IPv6 address. 
+    /// 
+    /// Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range (RFC 4291). When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
+    /// 
+    /// When formatting an IPADDRESS, any address within the mapped range will be formatted as an IPv4 address. Other addresses will be formatted as IPv6 using the canonical format defined in RFC 5952.
     IpAddress,
+    /// An IP routing prefix that can represent either an IPv4 or IPv6 address.
+    /// 
+    /// Internally, an address is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range (RFC 4291#section-2.5.5.2). When creating an IPPREFIX, IPv4 addresses will be mapped into that range. Additionally, addresses will be reduced to the first address of a network.
+    /// 
+    /// IPPREFIX values will be formatted in CIDR notation, written as an IP address, a slash (‘/’) character, and the bit-length of the prefix. Any address within the IPv4-mapped IPv6 address range will be formatted as an IPv4 address. Other addresses will be formatted as IPv6 using the canonical format defined in RFC 5952.
+    #[cfg(feature="presto")]
+    IpPrefix,
+    Geometry,
+    /// This type represents a UUID (Universally Unique IDentifier), also known as a GUID (Globally Unique IDentifier), using the format defined in RFC 4122.
     Uuid,
     Unknown,
 }
 
 impl RawPrestoTy {
+    #[deprecated(since = "0.7.0", note = "replaced with From trait implementation")]
+    #[inline(always)]
     pub fn to_str(&self) -> &'static str {
-        use RawPrestoTy::*;
-        match *self {
-            BigInt => "bigint",
-            Integer => "integer",
-            SmallInt => "smallint",
-            TinyInt => "tinyint",
-            Boolean => "boolean",
-            Date => "date",
-            Decimal => "decimal",
-            Real => "real",
-            Double => "double",
-            HyperLogLog => "HyperLogLog",
-            QDigest => "qdigest",
-            P4HyperLogLog => "P4HyperLogLog",
-            IntervalDayToSecond => "interval day to second",
-            IntervalYearToMonth => "interval year to month",
-            Timestamp => "timestamp",
-            TimestampWithTimeZone => "timestamp with time zone",
-            Time => "time",
-            TimeWithTimeZone => "time with time zone",
-            VarBinary => "varbinary",
-            VarChar => "varchar",
-            Char => "char",
-            Row => "row",
-            Array => "array",
-            Map => "map",
-            Json => "json",
-            IpAddress => "ipaddress",
-            Uuid => "uuid",
-            Unknown => "unknown",
-        }
+        self.into()
     }
 
+    #[deprecated(since = "0.7.0", note = "replaced with FromStr trait implementation")]
+    #[inline(always)]
     pub fn parse(s: &str) -> Option<Self> {
-        use RawPrestoTy::*;
-        let ty = match s {
-            "bigint" => BigInt,
-            "integer" => Integer,
-            "smallint" => SmallInt,
-            "tinyint" => TinyInt,
-            "boolean" => Boolean,
-            "date" => Date,
-            "decimal" => Decimal,
-            "real" => Real,
-            "double" => Double,
-            "HyperLogLog" => HyperLogLog,
-            "qdigest" => QDigest,
-            "P4HyperLogLog" => P4HyperLogLog,
-            "interval day to second" => IntervalDayToSecond,
-            "interval year to month" => IntervalYearToMonth,
-            "timestamp" => Timestamp,
-            "timestamp with time zone" => TimestampWithTimeZone,
-            "time" => Time,
-            "time with time zone" => TimeWithTimeZone,
-            "varbinary" => VarBinary,
-            "varchar" => VarChar,
-            "char" => Char,
-            "row" => Row,
-            "array" => Array,
-            "map" => Map,
-            "json" => Json,
-            "ipaddress" => IpAddress,
-            "uuid" => Uuid,
-            "unknown" => Unknown,
-            _ => return None,
-        };
-        Some(ty)
+        use std::str::FromStr;
+        RawPrestoTy::from_str(s).ok()
     }
 }
 
@@ -112,7 +121,7 @@ impl Serialize for RawPrestoTy {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_str())
+        serializer.serialize_str(self.into())
     }
 }
 
@@ -134,10 +143,7 @@ impl<'de> Deserialize<'de> for RawPrestoTy {
             where
                 E: de::Error,
             {
-                match RawPrestoTy::parse(v) {
-                    Some(d) => Ok(d),
-                    None => Err(E::custom(format!("invalid presto type: {}", v))),
-                }
+                v.try_into().map_err(|_| E::custom(format!("invalid presto type: {}", v)))
             }
         }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,30 +1,15 @@
-#[derive(Debug, Copy, Clone)]
-pub enum TransactionId {
-    NoTransaction,
-    StartTransaction,
-    RollBack,
-    Commit,
-}
+use strum::{Display, EnumString, IntoStaticStr};
 
-impl TransactionId {
-    pub fn to_str(&self) -> &'static str {
-        use TransactionId::*;
-        match *self {
-            NoTransaction => "NONE",
-            StartTransaction => "START TRANSACTION",
-            RollBack => "ROLLBACK",
-            Commit => "COMMIT",
-        }
-    }
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "NONE" => Some(Self::NoTransaction),
-            "START TRANSACTION" => Some(Self::StartTransaction),
-            "ROLLBACK" => Some(Self::RollBack),
-            "COMMIT" => Some(Self::Commit),
-            _ => None,
-        }
-    }
+#[derive(Debug, Copy, Clone, Display, EnumString, IntoStaticStr)]
+pub enum TransactionId {
+    #[strum(serialize = "NONE")]
+    NoTransaction,
+    #[strum(serialize = "START TRANSACTION")]
+    StartTransaction,
+    #[strum(serialize = "ROLLBACK")]
+    RollBack,
+    #[strum(serialize = "COMMIT")]
+    Commit,
 }
 
 impl Default for TransactionId {

--- a/src/types/data_set.rs
+++ b/src/types/data_set.rs
@@ -88,8 +88,8 @@ impl<T: Presto> Serialize for DataSet<T> {
 
         let columns = self.types.clone().map(|(name, ty)| Column {
             name,
-            ty: ty.full_type().into_owned(),
-            type_signature: Some(ty.into_type_signature()),
+            ty: ty.to_string(),
+            type_signature: Some(ty.into()),
         });
 
         let data = SerializeIterator {
@@ -133,7 +133,7 @@ impl<'de, T: Presto> Deserialize<'de> for DataSet<T> {
             {
                 let types = if let Some(Field::Columns) = map.next_key()? {
                     let columns: Vec<Column> = map.next_value()?;
-                    columns.try_map(PrestoTy::from_column).map_err(|e| {
+                    columns.try_map(|col| col.try_into()).map_err(|e| {
                         de::Error::custom(format!("deserialize presto type failed, reason: {}", e))
                     })?
                 } else {

--- a/src/types/option.rs
+++ b/src/types/option.rs
@@ -3,6 +3,8 @@ use std::marker::PhantomData;
 
 use serde::de::{self, DeserializeSeed, Deserializer, Visitor};
 
+use crate::RawPrestoTy;
+
 use super::{Context, Presto, PrestoTy};
 
 impl<T: Presto> Presto for Option<T> {
@@ -44,7 +46,7 @@ impl<'a, T> OptionSeed<'a, T> {
 impl<'a, 'de, T: Presto> Visitor<'de> for OptionSeed<'a, T> {
     type Value = Option<T>;
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str(T::ty().raw_type().to_str())
+        formatter.write_str(RawPrestoTy::from(T::ty()).into())
     }
 
     fn visit_none<E>(self) -> Result<Self::Value, E>


### PR DESCRIPTION
I noticed some from_str impls should be using `FromStr` trait instead, so I converted them. I additionally simplified some macros since the compiler now knows that all its callers implement FromStr. 

Figuring out how to turn `set_header!` into a pure function as well, but since it takes `Optional` which doesn't have a `FromStr` impl, will have to think of a relatively clever solution. 