### PR TITLE
Adds visiting unit type for optional data

### DIFF
--- a/src/types/option.rs
+++ b/src/types/option.rs
@@ -54,6 +54,13 @@ impl<'a, 'de, T: Presto> Visitor<'de> for OptionSeed<'a, T> {
         Ok(None)
     }
 
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(None)
+    }
+
     fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,

--- a/tests/data/models/query_result_empty
+++ b/tests/data/models/query_result_empty
@@ -120,6 +120,21 @@
                     }
                 ]
             }
+        },
+        {
+            "name": "f",
+            "type": "varchar(3)",
+            "typeSignature": {
+                "rawType": "varchar",
+                "typeArguments": [],
+                "literalArguments": [],
+                "arguments": [
+                    {
+                        "kind": "LONG",
+                        "value": 3
+                    }
+                ]
+            }
         }
     ],
     "stats": {

--- a/tests/data/models/query_result_finished
+++ b/tests/data/models/query_result_finished
@@ -120,6 +120,21 @@
                     }
                 ]
             }
+        },
+        {
+            "name": "f",
+            "type": "varchar(3)",
+            "typeSignature": {
+                "rawType": "varchar",
+                "typeArguments": [],
+                "literalArguments": [],
+                "arguments": [
+                    {
+                        "kind": "LONG",
+                        "value": 3
+                    }
+                ]
+            }
         }
     ],
     "data": [
@@ -135,7 +150,8 @@
             [
                 1,
                 1.1
-            ]
+            ],
+            null
         ]
     ],
     "stats": {

--- a/tests/query_result.rs
+++ b/tests/query_result.rs
@@ -20,6 +20,7 @@ struct A {
     c: bool,
     d: Vec<i32>,
     e: B,
+    f: Option<String>,
 }
 
 #[derive(Presto, PartialEq, Debug, Clone)]


### PR DESCRIPTION
When field is optional the QueryResult will end up visiting a unit type instead of an option type (none or some). This is part of the default implementation of serde (as opposed to serde_json). For some reason, the nesting of the field `data_set` within it seems to trigger a fallback to the original serde code and not the serde_json code.

To reproduce this, an optional field is added to the query result finished test. This value is then set to null in the test data and loaded in. Specifying that it visits a unit corrects the behavior by mapping it to a None value.

Fixes #37