### PR TITLE
add Client method returning a stream of rows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "1.4"
 regex = "1.5"
 # network dependencies
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"]}
-futures = "0.3"
+futures = "0.3.30"
 http = "0.2"
 tokio = { version = "1.16", features = ["full"]}
 urlencoding = "2.1"


### PR DESCRIPTION
This is a convenience so users can just iterate over a stream of rows.  It also opens up the possibility of using `TryStream` combinators, although honestly I haven't found those all that useful.