### PR TITLE
feat: add json support

### DIFF
--- a/src/models/column.rs
+++ b/src/models/column.rs
@@ -34,12 +34,11 @@ pub struct NamedTypeSignature {
     pub type_signature: TypeSignature,
 }
 
+#[non_exhaustive]
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RowFieldName {
     pub name: String,
-    #[serde(skip)]
-    delimited: (), // deprecated
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -146,10 +145,7 @@ impl TypeSignature {
 
 impl RowFieldName {
     pub fn new(name: String) -> Self {
-        RowFieldName {
-            name,
-            delimited: (),
-        }
+        RowFieldName { name }
     }
 }
 
@@ -264,7 +260,6 @@ mod tests {
                     NamedTypeSignature {
                         field_name: Some(RowFieldName {
                             name: "y".to_string(),
-                            delimited: (),
                         }),
                         type_signature: TypeSignature {
                             raw_type: RawPrestoTy::Double,

--- a/src/models/ty.rs
+++ b/src/models/ty.rs
@@ -154,6 +154,10 @@ mod tests {
         let ty = RawPrestoTy::Char;
         let s = serde_json::to_string(&ty).unwrap();
         assert_eq!(s, "\"char\"");
+
+        let ty = RawPrestoTy::Json;
+        let s = serde_json::to_string(&ty).unwrap();
+        assert_eq!(s, "\"json\"");
     }
 
     #[test]
@@ -161,6 +165,10 @@ mod tests {
         let data = "\"char\"";
         let ty = serde_json::from_str::<RawPrestoTy>(data).unwrap();
         assert_eq!(ty, RawPrestoTy::Char);
+
+        let data = "\"json\"";
+        let ty = serde_json::from_str::<RawPrestoTy>(data).unwrap();
+        assert_eq!(ty, RawPrestoTy::Json);
 
         let invalid = "\"xxx\"";
         let res = serde_json::from_str::<RawPrestoTy>(invalid);

--- a/src/selected_role.rs
+++ b/src/selected_role.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use regex::Regex;
+use std::fmt::Display;
 
 #[derive(Debug, PartialEq)]
 pub enum RoleType {
@@ -36,25 +37,27 @@ impl SelectedRole {
     }
 }
 
-impl ToString for RoleType {
-    fn to_string(&self) -> String {
+impl Display for RoleType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use RoleType::*;
-        match self {
+        let str = match self {
             Role => "ROLE".to_string(),
             All => "ALL".to_string(),
             None => "NONE".to_string(),
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 
-impl ToString for SelectedRole {
-    fn to_string(&self) -> String {
+impl Display for SelectedRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let ty = self.ty.to_string();
-        if let Some(role) = &self.role {
+        let str = if let Some(role) = &self.role {
             format!("{}{{{}}}", ty, role)
         } else {
             ty
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -1,0 +1,37 @@
+use crate::{Context, Presto, PrestoTy};
+use serde::de::DeserializeSeed;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+
+impl Presto for Value {
+    type ValueType<'a> = &'a Value;
+    type Seed<'a, 'de> = ValueSeed;
+
+    fn value(&self) -> Self::ValueType<'_> {
+        self
+    }
+
+    fn ty() -> PrestoTy {
+        PrestoTy::Json
+    }
+
+    fn seed<'a, 'de>(ctx: &'a Context<'a>) -> Self::Seed<'a, 'de> {
+        ValueSeed
+    }
+
+    fn empty() -> Self {
+        Value::empty()
+    }
+}
+
+pub struct ValueSeed;
+
+impl<'de> DeserializeSeed<'de> for ValueSeed {
+    type Value = Value;
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        <Value as Deserialize<'de>>::deserialize(deserializer)
+    }
+}

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -15,12 +15,12 @@ impl Presto for Value {
         PrestoTy::Json
     }
 
-    fn seed<'a, 'de>(ctx: &'a Context<'a>) -> Self::Seed<'a, 'de> {
+    fn seed<'a, 'de>(_: &'a Context<'a>) -> Self::Seed<'a, 'de> {
         ValueSeed
     }
 
     fn empty() -> Self {
-        Value::empty()
+        Default::default()
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -14,7 +14,7 @@ mod option;
 mod row;
 mod seq;
 mod string;
-pub(self) mod util;
+mod util;
 pub mod uuid;
 
 pub use self::uuid::*;
@@ -42,16 +42,14 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::sync::Arc;
 
-use derive_more::Display;
-use iterable::*;
-use serde::de::{DeserializeSeed, IntoDeserializer};
-use serde::Serialize;
-
-use crate::PrestoTy::Uuid;
 use crate::{
     ClientTypeSignatureParameter, Column, NamedTypeSignature, RawPrestoTy, RowFieldName,
     TypeSignature,
 };
+use derive_more::Display;
+use iterable::*;
+use serde::de::DeserializeSeed;
+use serde::Serialize;
 
 //TODO: refine it
 #[derive(Display, Debug)]
@@ -94,7 +92,7 @@ impl<'a> Context<'a> {
     pub fn new<T: Presto>(provided: &'a PrestoTy) -> Result<Self, Error> {
         let target = T::ty();
         let ret = extract(&target, provided)?;
-        let map = HashMap::from_iter(ret.into_iter());
+        let map = HashMap::from_iter(ret);
         Ok(Context {
             ty: provided,
             map: Arc::new(map),

--- a/tests/data/types/json
+++ b/tests/data/types/json
@@ -1,0 +1,19 @@
+{
+    "columns": [
+        {
+            "name": "a",
+            "type": "json",
+            "typeSignature": {
+                "rawType": "json",
+                "typeArguments": [],
+                "literalArguments": [],
+                "arguments": []
+            }
+        }
+    ],
+    "data": [
+        [
+            "abc"
+        ]
+    ]
+}

--- a/tests/data_set.rs
+++ b/tests/data_set.rs
@@ -52,6 +52,19 @@ fn split(v: Value) -> Option<(Vec<Column>, Value)> {
 }
 
 #[test]
+fn test_json() {
+    let (s, v) = read("json");
+    let d = serde_json::from_str::<DataSet<Row>>(&s).unwrap();
+    assert_ds(d.clone(), v);
+    let d = d.into_vec();
+    assert_eq!(d.len(), 1);
+    assert_eq!(
+        d[0].clone().into_json(),
+        vec![Value::String("abc".to_string())]
+    );
+}
+
+#[test]
 fn test_char() {
     #[derive(Presto, Eq, PartialEq, Debug, Clone)]
     struct A {


### PR DESCRIPTION
Add support for trino json data type, trino json data type reference is based on
https://trino.io/docs/current/language/types.html#json