### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/nooberfsh/prusto/compare/prusto-v0.5.1...prusto-v0.5.2) - 2024-12-06
+
+### Added
+
+- add timestamp with timezone support
+- add json support
+
+### Fixed
+
+- fix cargo clippy warnings
+
+### Other
+
+- add auth info to the next_uri request
+- support up to 32 fields for Structs
+- Adds visiting unit type for optional data
+- allow unverified certificates
+- update changelog
+
 ## [0.5.1] - 2023-10-19
 - Make Client::get and some functions public [#29](https://github.com/nooberfsh/prusto/pull/29)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusto"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["nooberfsh <nooberfsh@gmail.com>"]
 edition = "2021"
 description = "A presto/trino client library"

--- a/prusto-macros/CHANGELOG.md
+++ b/prusto-macros/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/nooberfsh/prusto/compare/prusto-macros-v0.2.0...prusto-macros-v0.2.1) - 2024-12-06
+
+### Other
+
+- support up to 32 fields for Structs

--- a/prusto-macros/Cargo.toml
+++ b/prusto-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prusto-macros"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["nooberfsh <nooberfsh@gmail.com>"]
 edition = "2021"
 description = "prusto macros"


### PR DESCRIPTION
## 🤖 New release
* `prusto`: 0.5.1 -> 0.5.2
* `prusto-macros`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `prusto`
<blockquote>

## [0.5.2](https://github.com/nooberfsh/prusto/compare/prusto-v0.5.1...prusto-v0.5.2) - 2024-12-06

### Added

- add timestamp with timezone support
- add json support

### Fixed

- fix cargo clippy warnings

### Other

- add auth info to the next_uri request
- support up to 32 fields for Structs
- Adds visiting unit type for optional data
- allow unverified certificates
- update changelog
</blockquote>

## `prusto-macros`
<blockquote>

## [0.2.1](https://github.com/nooberfsh/prusto/compare/prusto-macros-v0.2.0...prusto-macros-v0.2.1) - 2024-12-06

### Other

- support up to 32 fields for Structs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).