### PR TITLE
Adding support to bearer auth token support to client

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,11 +3,16 @@ use std::fmt;
 #[derive(Clone)]
 pub enum Auth {
     Basic(String, Option<String>),
+    Bearer(String),
 }
 
 impl Auth {
     pub fn new_basic(username: impl ToString, password: Option<impl ToString>) -> Auth {
         Auth::Basic(username.to_string(), password.map(|p| p.to_string()))
+    }
+
+    pub fn new_bearer(bearer_token: impl ToString) -> Auth {
+        Auth::Bearer(bearer_token.to_string())
     }
 }
 
@@ -18,6 +23,10 @@ impl fmt::Debug for Auth {
                 .debug_struct("BasicAuth")
                 .field("username", name)
                 .field("password", &"******")
+                .finish(),
+            Auth::Bearer(_) => f
+                .debug_struct("BearerAuth")
+                .field("token", &"******")
                 .finish(),
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -481,6 +481,7 @@ impl Client {
         if let Some(auth) = self.auth.as_ref() {
             match auth {
                 Auth::Basic(u, p) => req.basic_auth(u, p.as_ref()),
+                Auth::Bearer(t) => req.bearer_auth(t),
             }
         } else {
             req


### PR DESCRIPTION
## Motivation
The `Auth` enum only supported `Basic` authentication, making it impossible to connect to gateways that require JWT/Bearer token auth via the `Authorization: Bearer <token>` header.

## Changes
- Added `Bearer(String)` variant to the `Auth` enum
- Added `Auth::new_bearer()` constructor
- Added `bearer_auth` handling in `Client::auth_req`

## Usage
```rust
let client = ClientBuilder::new(user, host)
    .auth(Auth::new_bearer(token))
    .build()?;
```

This is my first Rust PR and first FOSS PR, I am picking up the details of the language so if there is anything lacking please let me know. I checked for auth related tests but could not find any.